### PR TITLE
Add data ingestion notebook scaffold

### DIFF
--- a/notebooks/01_data_ingestion.ipynb
+++ b/notebooks/01_data_ingestion.ipynb
@@ -1,0 +1,18 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# 01_data_ingestion.ipynb\n",
+        "\n",
+        "## 1. Data Sources\n",
+        "## 2. Load into Pandas\n",
+        "## 3. Summary Statistics"
+      ]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds the initial notebook for data ingestion:

- Creates `notebooks/01_data_ingestion.ipynb` with sections for:
  - Data sources
  - Loading into Pandas
  - Summary statistics

Closes #1
